### PR TITLE
simplified the cpm_rdline function and added handling of eof

### DIFF
--- a/bin/zxcbdos.c
+++ b/bin/zxcbdos.c
@@ -5,6 +5,7 @@
 #ifdef __MSDOS__
 #include <conio.h>
 #endif
+extern int eof_conin;
 
 /* Line input */
 /* modified to allow <file even is USE_CPMIO is defined */
@@ -20,42 +21,28 @@ void bdos_rdline(word line, word *PC)
     }
 #endif
     /* if USE_CPMIO is not defined or stdin is redirected from a file */
-    /* cpm rdline accepts up to specified number of characters
-     * the terminating \r or \n is excluded from this count
-     * additionally using fgets adds a \0 at the end of line
-     * which should also be excluded from the count
-     * to support this the fgets reads to a temporary buffer
-     * that has two bytes in case the specified number of bytes
-     * are on the line, before the \n
-     * unix also doesn't convert \r\n to \n so additional
-     * processing is required to skip the \r
+    /* this version does not use fgets as it introduces complexities
+     * as it needs a trailing '\0' and does not translate \r\n
+     * under unix / linux
      */
 	int maxlen = RAM[line];
-    char buf[257];     /* allow for 255 byte input + eol + '\0' */
-    int len;
-
-	if (fgets(buf, maxlen + 2, stdin)) {    /* allow for \0 terminator */
-        len = strlen(buf);
-        if (len && buf[len - 1] == '\n') {
-            if (--len && buf[len - 1] == '\r')  /* fix \r\n under unix */
-                len--;
-        } else if (len && buf[len - 1] == '\r') {  /* max line under unix */
-            int c;
-            if ((c = getc(stdin)) != '\n')  /* absorb the \n */
-                ungetc(c, stdin);
-            len--;
-        } else if (len > maxlen)    /* line longer than maxlen */
-            ungetc(buf[--len], stdin);   /* so unget extra char */
-    } else
-        len = 0;
-	RAM[line + 1] = len;
-    if (len)
-        memcpy(&RAM[line + 2], buf, len);
-    if (file_conin) {      /* echo to the console if from file */
-        for (int i = 0; i < len; i++)
-            cpm_conout(buf[i]);
+    int len = 0;
+    int c;
+    while ((c = cpm_conin()) != '\n' && !eof_conin) {
+        if (c != '\r' && len < maxlen) {
+            RAM[line + 2 + len++] = c;
+            if (file_conin) {
+                if (c < 0x20) {
+                    cpm_conout(c);
+                    c += 0x40;
+                }
+                cpm_conout(c);
+            }
+        }
+    }
+    if (file_conin)
         cpm_conout('\r');
-    } 
+    RAM[line + 1] = len;
 	Msg("Input: [%d] %-*.*s\n", RAM[line + 1], RAM[line + 1], RAM[line +1], (char *)(RAM+line+2));
 }
 

--- a/cpmio/lib/conbdos.c
+++ b/cpmio/lib/conbdos.c
@@ -416,15 +416,8 @@ static int check_ctls(int called_by_func_11)
 {
 	char ch;
 
-
-	if (called_by_func_11)
-	{
-		if (console_mode & 2) return constat();
-	}
-	else if (console_mode & 2) return 0;	/* Not checking ^S */
-
-    if (file_conin)
-        return constat();
+    if (file_conin || (console_mode & 2))
+        return called_by_func_11 ? constat() : 0;   /* 0 if not using ctrl S */
 
 	ch = kbchar;
 	if (!(called_by_func_11 && kbchar))


### PR DESCRIPTION
Removed fgets from cpm_rdline, simplifying the code and allowing '\0' to be read.
Long lines are now truncated as would be the case on real console input and control characters are displayed in the usual ^char format, if echoing from redirected stdin.
Also added support to detect EOF, the termios_conin was also modified as the read function looped, on error or EOF and potentially could loop for ever.
On EOF or error the flag eof_conin is set, and the character returned is ^Z. 
Note tools using ^Z in rdline will work as it distinguishes between ^Z and eof .
check_ctls was also refactored