### PR TITLE
added open file tracking

### DIFF
--- a/cpmredir/config.h.in
+++ b/cpmredir/config.h.in
@@ -108,3 +108,6 @@
 
 /* Define to `long int' if <sys/types.h> does not define. */
 #undef off_t
+
+/* define if tracking open files */
+#define FILETRACKER 1

--- a/cpmredir/lib/Makefile.in
+++ b/cpmredir/lib/Makefile.in
@@ -81,7 +81,7 @@ libcpmredir_a_AR = $(AR) $(ARFLAGS)
 libcpmredir_a_LIBADD =
 am_libcpmredir_a_OBJECTS = cpmdrv.$(OBJEXT) cpmredir.$(OBJEXT) \
 	util.$(OBJEXT) cpmglob.$(OBJEXT) cpmparse.$(OBJEXT) \
-	drdos.$(OBJEXT) xlt.$(OBJEXT)
+	drdos.$(OBJEXT) xlt.$(OBJEXT) track.$(OBJEXT)
 libcpmredir_a_OBJECTS = $(am_libcpmredir_a_OBJECTS)
 DEFAULT_INCLUDES = -I.@am__isrc@ -I$(top_builddir)
 depcomp = $(SHELL) $(top_srcdir)/config/depcomp
@@ -217,7 +217,7 @@ top_srcdir = @top_srcdir@
 INCLUDES = -I$(top_srcdir)/include
 lib_LIBRARIES = libcpmredir.a
 libcpmredir_a_SOURCES = cpmdrv.c   cpmint.h	  cpmredir.c  util.c \
-		   cpmglob.c  cpmparse.c  drdos.c     xlt.c
+		   cpmglob.c  cpmparse.c  drdos.c     xlt.c track.c
 
 all: all-am
 
@@ -301,6 +301,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/drdos.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/util.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/xlt.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/track.Po@am__quote@
 
 .c.o:
 @am__fastdepCC_TRUE@	$(COMPILE) -MT $@ -MD -MP -MF $(DEPDIR)/$*.Tpo -c -o $@ $<

--- a/cpmredir/lib/cpmint.h
+++ b/cpmredir/lib/cpmint.h
@@ -214,3 +214,12 @@ cpm_word redir_password_error(void);
 /* Append password to filename (FILE.TYP -> FILE.TYP;PASSWORD) */
 void redir_password_append(char *s, cpm_byte *dma);
 
+#if defined(FILETRACKER)
+void releaseFile(char *fname);
+int trackFile(char *fname, void *fcb, int fd);
+#else
+inline void releaseFile(char* fname) {}
+inline int trackFile(char* fname, void* fcb, int fd) { return fd; }
+#endif
+/* helper macro */
+#define releaseFCB(fcb) trackFile(NULL, fcb, -1)

--- a/cpmredir/lib/util.c
+++ b/cpmredir/lib/util.c
@@ -1,26 +1,31 @@
 /*
 
-    CPMREDIR: CP/M filesystem redirector
-    Copyright (C) 1998, John Elliott <jce@seasip.demon.co.uk>
+	CPMREDIR: CP/M filesystem redirector
+	Copyright (C) 1998, John Elliott <jce@seasip.demon.co.uk>
 
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Library General Public
-    License as published by the Free Software Foundation; either
-    version 2 of the License, or (at your option) any later version.
+	This library is free software; you can redistribute it and/or
+	modify it under the terms of the GNU Library General Public
+	License as published by the Free Software Foundation; either
+	version 2 of the License, or (at your option) any later version.
 
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Library General Public License for more details.
+	This library is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+	Library General Public License for more details.
 
-    You should have received a copy of the GNU Library General Public
-    License along with this library; if not, write to the Free
-    Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+	You should have received a copy of the GNU Library General Public
+	License along with this library; if not, write to the Free
+	Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
-    This file holds miscellaneous utility functions.
+	This file holds miscellaneous utility functions.
 */
 
 #include "cpmint.h"
+
+
+
+
+
 
 /* In debug mode, lseek()s can be traced. */
 
@@ -30,23 +35,23 @@ long zxlseek(int fd, long offset, int wh)
 {
 	long v = lseek(fd, offset, wh);
 	if (v >= 0) return v;
-	
+
 	redir_Msg("lseek fails with errno = %d\n", errno);
 	if (errno == EBADF)  redir_Msg("     (bad file descriptor %d)\n", fd);
-	if (errno == ESPIPE) redir_Msg("     (file %d is a pipe)\n",      fd);
-	if (errno == EINVAL) redir_Msg("     (bad parameter %d)\n",       wh);
+	if (errno == ESPIPE) redir_Msg("     (file %d is a pipe)\n", fd);
+	if (errno == EINVAL) redir_Msg("     (bad parameter %d)\n", wh);
 
 	return -1;
 }
 
 
-void redir_showfcb(cpm_byte *fd)
+void redir_showfcb(cpm_byte* fd)
 {
 	int n;
 
 	for (n = 0; n < 32; n++)
 	{
-		if (!n || n>= 12) printf("%02x ", fd[n]);
+		if (!n || n >= 12) printf("%02x ", fd[n]);
 		else		  printf("%c", fd[n] & 0x7F);
 	}
 	printf("\r\n");
@@ -56,22 +61,22 @@ void redir_showfcb(cpm_byte *fd)
 
 /* Get the "sequential access" file pointer out of an FCB */
 
-long redir_get_fcb_pos(cpm_byte *fcb)
+long redir_get_fcb_pos(cpm_byte* fcb)
 {
 	long npos;
 
-        npos  = 524288L * fcb[0x0E];      /* S2 */
-        npos  += 16384L * fcb[0x0C];      /* Extent */
-        npos  += 128L   * fcb[0x20];      /* Record */
+	npos = 524288L * fcb[0x0E];      /* S2 */
+	npos += 16384L * fcb[0x0C];      /* Extent */
+	npos += 128L * fcb[0x20];      /* Record */
 
 	return npos;
 }
 
-void redir_put_fcb_pos(cpm_byte *fcb, long npos)
+void redir_put_fcb_pos(cpm_byte* fcb, long npos)
 {
-        fcb[0x20] = (npos / 128) % 128;
-        fcb[0x0C] = (npos / 16384) % 32;
-        fcb[0x0E] = (npos / 524288L) % 64;
+	fcb[0x20] = (npos / 128) % 128;
+	fcb[0x0C] = (npos / 16384) % 32;
+	fcb[0x0E] = (npos / 524288L) % 64;
 }
 
 
@@ -80,29 +85,29 @@ void redir_put_fcb_pos(cpm_byte *fcb, long npos)
 /* Passed a CP/M FCB, convert it to a unix filename. Turn its drive back into
  * a path. */
 
-int redir_fcb2unix(cpm_byte *fcb, char *fname)
+int redir_fcb2unix(cpm_byte* fcb, char* fname)
 {
 	int n, q, drv, ddrv;
 	char s[2];
 
 	s[1] = 0;
-	q    = 0;
-	drv  = fcb[0] & 0x7F;
+	q = 0;
+	drv = fcb[0] & 0x7F;
 	if (drv == '?') drv = 0;
 
-	ddrv = fcb[0] & 0x7F; 
+	ddrv = fcb[0] & 0x7F;
 	if (ddrv < 0x1F) ddrv += '@';
 
 	redir_Msg("%c:%-8.8s.%-3.3s\n",
-	    ddrv,
-            fcb + 1,
-            fcb + 9);
+		ddrv,
+		fcb + 1,
+		fcb + 9);
 
 	if (!drv) strcpy(fname, redir_drive_prefix[redir_cpmdrive]);
 	else	  strcpy(fname, redir_drive_prefix[drv - 1]);
 
 	for (n = 1; n < 12; n++)
-	{	
+	{
 		s[0] = (fcb[n] & 0x7F);
 		if (s[0] == '?') q = 1;
 		if (isupper(s[0])) s[0] = tolower(s[0]);
@@ -119,50 +124,51 @@ int redir_fcb2unix(cpm_byte *fcb, char *fname)
 #define EROFS EACCES
 #endif
 
-int redir_ofile(cpm_byte *fcb, char *s)
+int redir_ofile(cpm_byte* fcb, char* s)
 {
 	int h, rv;
 
-       /* Software write-protection */
+	   /* Software write-protection */
 #ifdef __MSDOS__
-	if (!redir_ro_fcb(fcb)) 
+	if (!redir_ro_fcb(fcb))
 	{
 		rv = _dos_open(s, O_RDWR, &h);
 		if (!rv) return h;
 		redir_Msg("Open of %s fails: error %x\r\n", s, rv);
 	}
 	rv = _dos_open(s, O_RDONLY, &h);
-	if (rv) return -1;
-        fcb[9] |= 0x80;
+	if (rv != 0)
+	    fcb[9] |= 0x80;
 #else
 	(void)rv;	/* Stop compiler warning */
-	if (!redir_ro_fcb(fcb)) 
+	if (!redir_ro_fcb(fcb))
 	{
 		h = open(s, O_RDWR | O_BINARY);
-		if (h >= 0 || (errno != EACCES && errno != EROFS)) return h;
+		if (h >= 0 || (errno != EACCES && errno != EROFS))
+			return trackFile(s, fcb,  h);
 	}
 	h = open(s, O_RDONLY | O_BINARY);
-	if (h < 0) return -1;
+	if (h >= 0)
         fcb[9] |= 0x80;
 #endif
-	return h;
+	return trackFile(s, fcb, h >= 0 ? h : -1);
 }
 
 
 /* Extract a file handle from where it was stored in an FCB by fcb_open()
-  or fcb_creat(). Aborts if the FCB has been tampered with. 
+  or fcb_creat(). Aborts if the FCB has been tampered with.
 
   Note: Some programs (like GENCOM) close FCBs they never opened. This causes
   the Corrupt FCB message, but no harm seems to ensue. */
 
-int redir_verify_fcb(cpm_byte *fcb)
+int redir_verify_fcb(cpm_byte* fcb)
 {
-        if (fcb[16] != 0xFD || fcb[17] != 0x00)
-        {
-                fprintf(stderr,"cpmredir: Corrupt FCB\n");
-		return -1; 
+	if (fcb[16] != 0xFD || fcb[17] != 0x00)
+	{
+		fprintf(stderr, "cpmredir: Corrupt FCB\n");
+		return -1;
 	}
-        return (int)(redir_rd32(fcb + 18));
+	return (int)(redir_rd32(fcb + 18));
 
 }
 
@@ -170,15 +176,15 @@ int redir_verify_fcb(cpm_byte *fcb)
 
 #ifdef DEBUG
 
-void redir_Msg(char *s, ...)
+void redir_Msg(char* s, ...)
 {
-        va_list ap;
+	va_list ap;
 
-        va_start(ap, s);
-        printf("cpmredir trace: ");
-        vprintf(s, ap);
-        va_end(ap);
-        fflush(stdout);
+	va_start(ap, s);
+	printf("cpmredir trace: ");
+	vprintf(s, ap);
+	va_end(ap);
+	fflush(stdout);
 }
 
 #endif
@@ -188,26 +194,26 @@ void redir_Msg(char *s, ...)
 /* Convert time_t to CP/M day count/hours/minutes */
 dword redir_cpmtime(time_t t)
 {
-        long d  = (t / 86400) - 2921;  /* CP/M day 0 is unix day 2921 */
-        long h  = (t % 86400) / 3600;  /* Hour, 0-23 */
-        long m  = (t % 3600)  / 60;    /* Minute, 0-59 */
+	long d = (t / 86400) - 2921;  /* CP/M day 0 is unix day 2921 */
+	long h = (t % 86400) / 3600;  /* Hour, 0-23 */
+	long m = (t % 3600) / 60;    /* Minute, 0-59 */
 
-        return (d | (BCD(h) << 16) | (BCD(m) << 24));
+	return (d | (BCD(h) << 16) | (BCD(m) << 24));
 }
 
 #undef BCD
 
 #define UNBCD(x) (((x % 16) + 10 * (x / 16)) & 0xFF)
 
-time_t redir_unixtime(cpm_byte *c)
+time_t redir_unixtime(cpm_byte* c)
 {
 	time_t t;
 	cpm_word days;
 
 	days = (c[0] + 256 * c[1]) + 2921;
 
-	t =  60L    * UNBCD(c[3]);
-	t += 3600L  * UNBCD(c[2]);
+	t = 60L * UNBCD(c[3]);
+	t += 3600L * UNBCD(c[2]);
 	t += 86400L * days;
 
 	return t;
@@ -219,52 +225,52 @@ time_t redir_unixtime(cpm_byte *c)
 /* Functions to access 24-bit & 32-bit words in memory. These are always
   little-endian. */
 
-void redir_wr24(cpm_byte *addr, dword v)
+void redir_wr24(cpm_byte* addr, dword v)
 {
-	addr[0] =  v        & 0xFF;
-	addr[1] = (v >> 8)  & 0xFF;
+	addr[0] = v & 0xFF;
+	addr[1] = (v >> 8) & 0xFF;
 	addr[2] = (v >> 16) & 0xFF;
 }
 
-void redir_wr32(cpm_byte *addr, dword v)
+void redir_wr32(cpm_byte* addr, dword v)
 {
-        addr[0] =  v        & 0xFF;
-        addr[1] = (v >> 8)  & 0xFF;
-        addr[2] = (v >> 16) & 0xFF;
+	addr[0] = v & 0xFF;
+	addr[1] = (v >> 8) & 0xFF;
+	addr[2] = (v >> 16) & 0xFF;
 	addr[3] = (v >> 24) & 0xFF;
 }
 
-dword redir_rd24(cpm_byte *addr)
+dword redir_rd24(cpm_byte* addr)
 {
 	register dword rv = addr[2];
-	
+
 	rv = (rv << 8) | addr[1];
 	rv = (rv << 8) | addr[0];
 	return rv;
 }
 
 
-dword redir_rd32(cpm_byte *addr)
+dword redir_rd32(cpm_byte* addr)
 {
-        register dword rv = addr[3];
+	register dword rv = addr[3];
 
 	rv = (rv << 8) | addr[2];
-        rv = (rv << 8) | addr[1];
-        rv = (rv << 8) | addr[0];
-        return rv;
+	rv = (rv << 8) | addr[1];
+	rv = (rv << 8) | addr[0];
+	return rv;
 }
 
 
 void redir_log_drv(cpm_byte drv)
 {
 	if (!drv) redir_l_drives |= 1;
-        else redir_l_drives |= (1L << drv);
+	else redir_l_drives |= (1L << drv);
 }
 
-void redir_log_fcb(cpm_byte *fcb)
+void redir_log_fcb(cpm_byte* fcb)
 {
 	int drv = fcb[0] & 0x7F;
-	
+
 	if (drv && drv != '?') redir_log_drv(drv - 1);
 	else redir_log_drv(redir_cpmdrive);
 }
@@ -276,7 +282,7 @@ int redir_ro_drv(cpm_byte drv)
 	else	  return redir_ro_drives & (1L << drv);
 }
 
-int redir_ro_fcb(cpm_byte *fcb)
+int redir_ro_fcb(cpm_byte* fcb)
 {
 	int drv = fcb[0] & 0x7F;
 
@@ -289,13 +295,13 @@ int redir_ro_fcb(cpm_byte *fcb)
 cpm_word redir_xlt_err(void)
 {
 	if (redir_password_error()) return 0x7FF;	/* DRDOS pwd error */
-	switch(errno)
-	{	
-		case EISDIR:
-		case EBADF:  return 9;		/* Bad FCB */
-		case EINVAL: return 0x03FF;	/* Readonly file */
-		case EPIPE:  return 0x01FF;	/* Broken pipe */
-		case ENOSPC: return 1;		/* No space */
-		default:     return 0xFF;	/* Software error */
+	switch (errno)
+	{
+	case EISDIR:
+	case EBADF:  return 9;		/* Bad FCB */
+	case EINVAL: return 0x03FF;	/* Readonly file */
+	case EPIPE:  return 0x01FF;	/* Broken pipe */
+	case ENOSPC: return 1;		/* No space */
+	default:     return 0xFF;	/* Software error */
 	}
 }


### PR DESCRIPTION
Adds support to track open/closed files, including auto closing files on fcb reuse and a function to close all handles open with a given filename.
Whilst not essential for Unix/Linux, for Windows, there should be no open handles for files that are being deleted / renamed
Note the original code allowed a potential violation of a CP/M constraint, in that a file being truncated should not be open, the tracking code now forces this constraint.
There is an optional flag FILETRACKER in config.h that can be undefined, to revert to previous behaviour.

As an example of the effectiveness, when building cgen.com from decompiled sources, the linq pass left 42 open files without the tracker and only 2 with it.

PS. The large number of changes in util.c are mainly due to an accidental reformat on my behalf