### PR TITLE
Modified xlt_name to handle all predefined paths

### DIFF
--- a/bin/zxc.c
+++ b/bin/zxc.c
@@ -7,7 +7,7 @@
 #include <ctype.h>
 
 static char cmdbuf[1024];
-char incdir80[CPM_MAXPATH] = { INCDIR80 };
+char incdir80[CPM_MAXPATH] = { INCDIR80 " "};
 
 static void mkpath(char* fullpath, char* path, char* subdir);
 int fname_opt(char *arg, char c)

--- a/bin/zxc.c
+++ b/bin/zxc.c
@@ -7,9 +7,7 @@
 #include <ctype.h>
 
 static char cmdbuf[1024];
-char incdir80[CPM_MAXPATH] = { INCDIR80 " "};
 
-static void mkpath(char* fullpath, char* path, char* subdir);
 int fname_opt(char *arg, char c)
 {
 	if ((arg[1] == c || arg[1] == toupper(c)) && arg[2])
@@ -24,7 +22,7 @@ int fname_opt(char *arg, char c)
 int cref_opt(char *arg)
 {
 	if ((arg[1] == 'c' || arg[1] == 'C') &&
-            (arg[2] == 'r' || arg[2] == 'r') && arg[3])
+            (arg[2] == 'r' || arg[2] == 'R') && arg[3])
 	{
 		strcat(cmdbuf, "-cr +");
 		strcat(cmdbuf, arg + 3);
@@ -39,15 +37,12 @@ int cref_opt(char *arg)
 int main(int argc, char **argv)
 {	
 	int n;
-	/* modified to use environment variables if defined */
-	char* tmpenv = getenv("INCDIR80");
-	if (tmpenv)
-		mkpath(incdir80, tmpenv, " ");
-	else if (tmpenv = getenv("CPMDIR80"))
-		mkpath(incdir80, tmpenv, INC80 " ");
 
-	strcpy(cmdbuf, "zxcc c.com --I +");
-	strcat(cmdbuf, incdir80);
+	/* note c: is predefined as the default include directory 
+	 * in zxcc. So use it
+	 */
+	strcpy(cmdbuf, "zxcc c.com --IC: ");
+
 
 	for (n = 1; n < argc; n++)
 	{
@@ -69,15 +64,4 @@ int main(int argc, char **argv)
 	return system(cmdbuf);
 }
 
-/* helper function to build full path */
-/* make sure that a / or \ is present at the end of path
- * before appending the subdir
- */
-static void mkpath(char* fullpath, char* path, char* subdir) {
-	char* s;
-	strcpy(fullpath, path);
-	s = strchr(fullpath, '\0');
-	if (*fullpath && !ISDIRSEP(s[-1]))  /* make sure we have dir sep */
-		*s++ = '/';
-	strcpy(s, subdir);
-}
+

--- a/bin/zxcc.c
+++ b/bin/zxcc.c
@@ -267,8 +267,9 @@ int main(int ac, char **av)
     /* DJGPP includes the whole path in the program name, which looks 
          * untidy...
          */
-    str = strrchr(progname, '/'); 
-    if (str) progname = str + 1;
+    while (str = strpbrk(progname, DIRSEP))
+        progname = str + 1;
+
 
     if (sizeof(int) > 8 || sizeof(byte) != 1 || sizeof(word) != 2)
     {

--- a/bin/zxcc.h
+++ b/bin/zxcc.h
@@ -5,10 +5,12 @@
 #include "config.h"
 #define ISDIRSEP(c) ((c) == '/')
 #define DIRSEPCH	'/'
+#define DIRSEP  "/"
 #else
 #include "config-win.h"
 #define ISDIRSEP(c) ((c) == '/' || (c) == '\\')
 #define DIRSEPCH	'\\'
+#define DIRSEP  "/\\:"
 #endif
 
 #ifndef CPMDIR80

--- a/cpmredir/lib/xlt.c
+++ b/cpmredir/lib/xlt.c
@@ -119,9 +119,9 @@ void xlt_name(char *localname, char *cpmname)
         strcat(cpmname, ibuf);
         return;
     }
-    /* catch user specified current directory p: or P: */
-    if (pname == ibuf + 2 && ibuf[1] == ':' && (ibuf[0] == 'P' || ibuf[0] == 'p')) {
-        cpmname[0] = 'p';               /* make sure it's lower case */
+    /* catch user specified current drive a,b,c,p or A,B,C,P only, which map to predefined directories  */
+    if (pname == ibuf + 2 && ibuf[1] == ':' && (s = strchr("aAbBcCpP", ibuf[0]))) {
+        cpmname[0] = tolower(*s);             /* make sure it's lower case */
         strcpy(cpmname + 1, ibuf + 1);
         return;
     }


### PR DESCRIPTION
Modified xlt_name to handle all predefined paths a:, b:, c:, p: when there are no directory components in the filename
Simplified zxc to use the above, note all the use of incdir80 in previous zxc and mkpath can be removed
Fixed parsing of progname to handle / or \ under windows.