### PR TITLE
Changed calculation for exact file size to match Hitech C assumptions

### DIFF
--- a/cpmredir/lib/cpmredir.c
+++ b/cpmredir/lib/cpmredir.c
@@ -151,7 +151,7 @@ cpm_word fcb_open(cpm_byte* fcb, cpm_byte* dma)
 				 */
 
 	/* Get the file length */
-	redir_wr32(fcb + LENGTH_OFFSET, zxlseek(handle, 0, SEEK_END));
+	redir_wr32(fcb + LENGTH_OFFSET, zxlseek(handle, 0, SEEK_CUR));
 	zxlseek(handle, 0, SEEK_SET);
 
 	/* Set the last record byte count */
@@ -170,7 +170,7 @@ cpm_word fcb_close(cpm_byte* fcb)
 	SHOWNAME("fcb_close")
 
 		if ((handle = redir_verify_fcb(fcb)) < 0) return -1;
-	redir_Msg("         (at   %lx)\n", zxlseek(handle, 0, SEEK_CUR));
+	redir_Msg("         (at   %lx)\n", zxlseek(handle, 0, SEEK_END));
 
 	if (fcb[0] & 0x80)	/* Close directory */
 	{
@@ -489,7 +489,10 @@ cpm_word fcb_randwr(cpm_byte* fcb, cpm_byte* dma)
 		/* Update the file length */
 	len = redir_rd32(fcb + LENGTH_OFFSET);
 	/* PMO: Bug fix, account for the data just written */
-	if (len < offs + rv) redir_wr32(fcb + LENGTH_OFFSET, offs + rv);
+	if (len < offs + rv) {
+		redir_wr32(fcb + LENGTH_OFFSET, offs + rv);
+		fcb[0x20] = (offs + rv) % 256;
+	}
 
 	if (rv < redir_rec_len) return 1;	/* disk full */
 	return 0;
@@ -765,7 +768,8 @@ cpm_word fcb_chmod(cpm_byte* fcb, cpm_byte* dma)
 		newoffs = offs = ((st.st_size + 127) / 128) * 128;
 		if (fcb[0x20] & 0x7F)
 		{
-			newoffs -= (0x80 - (fcb[0x20] & 0x7F));
+			newoffs -= fcb[0x20] & 0x7f;
+			//newoffs -= (0x80 - (fcb[0x20] & 0x7F));
 		}
 		if (newoffs == st.st_size)
 		{

--- a/winbuild/zxcc/zxcc.vcxproj
+++ b/winbuild/zxcc/zxcc.vcxproj
@@ -169,7 +169,7 @@ call "$(SolutionDir)Scripts\install.cmd" "$(SolutionDir)external\$(PlatformTarge
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions);USE_CPMIO</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions);USE_CPMIO;DEBUG;_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <AdditionalIncludeDirectories>..\include;..\..\cpmio\include;..\..\cpmredir\include</AdditionalIncludeDirectories>


### PR DESCRIPTION
After considerable detective work, I have established the reason $$exec.$$$ was behaving randomly is due to the code to set exact size. As noted elsewhere there are two ways the exact size is encoded, bytes used in last sector or bytes remaining. Unfortunately the one in zxcc, bytes used was the opposite to that used by Hitech C. Dependent on whether the last sector contained 64+ bytes would determine whether the file was truncated.

Also added a function to remote user # from file names as zxcc doesn't support real usage of user #. All flavours of user # supported by Hitech C are handled, with the additional constraint that user # <= 31. If greater than this it is unchanged.