### PR TITLE
Revert to original ZXCC exact size model.

### DIFF
--- a/bin/z80.c
+++ b/bin/z80.c
@@ -15,9 +15,9 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
-
+#include "zxcc.h"   // put first before calling windows include files                          
 #include<stdio.h>
-#include "zxcc.h"
+
 
 #define parity(a) (partable[a])
 

--- a/winbuild/zxcc/zxcc.vcxproj
+++ b/winbuild/zxcc/zxcc.vcxproj
@@ -169,7 +169,7 @@ call "$(SolutionDir)Scripts\install.cmd" "$(SolutionDir)external\$(PlatformTarge
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions);USE_CPMIO;DEBUG;_CRT_SECURE_NO_WARNINGS</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions);USE_CPMIO;DEBUG</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <AdditionalIncludeDirectories>..\include;..\..\cpmio\include;..\..\cpmredir\include</AdditionalIncludeDirectories>


### PR DESCRIPTION
cpmredir.c reverted to use original exact size model. Also undid an accidental bug introduced in the previous version.
Z80.c swapped include order to make sure config definition of _CRT_SECURE_NO_WARNINGS is picked up before loading system files
zxcc.vxcproj removed define of _CRT_SECURE_NO_WARNINGS, as it is in config file.
