### PR TITLE
add zxobjtohex, a wrapper for HiTech C OBJTOHEX.COM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ bin/zxc
 bin/zxcc
 bin/zxlibr
 bin/zxlink
+bin/zxobjtohex
 
 # libraries
 cpmio/lib/libcpmio.a

--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -1,9 +1,10 @@
 
-bin_PROGRAMS=zxcc zxc zxas zxlibr zxlink
+bin_PROGRAMS=zxcc zxc zxas zxlibr zxlink zxobjtohex
 
 zxc_SOURCES=zxc.c
 zxas_SOURCES=zxas.c
 zxlibr_SOURCES=zxlibr.c
+zxobjtohex_SOURCES=zxobjtohex.c
 zxcc_SOURCES=zxbdos.c    zxcbdos.c  zxdbdos.c   zxcc.c             \
-	     z80.c       z80.h      z80ops.h    cbops.h    edops.h \
+             z80.c       z80.h      z80ops.h    cbops.h    edops.h \
              zxbdos.h    zxcc.h	    zxcbdos.h   zxdbdos.h

--- a/bin/zxobjtohex.c
+++ b/bin/zxobjtohex.c
@@ -1,0 +1,25 @@
+
+#include "zxcc.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
+static char cmdbuf[1024];
+
+
+int main(int argc, char **argv)
+{	
+	int n;
+
+	strcpy(cmdbuf,"zxcc objtohex.com ");
+	for (n = 1; n < argc; n++)
+	{
+		if (argv[n][0] == '-')	/* An option */
+			strcat(cmdbuf,"-");
+		strcat(cmdbuf,argv[n]);
+		strcat(cmdbuf," ");
+	}	
+	return system(cmdbuf);
+}

--- a/zxcc.doc
+++ b/zxcc.doc
@@ -111,6 +111,9 @@ Using zxcc
    zxlibr
           The equivalent of LIBR.COM.
 
+   zxobjtohex
+          The equivalent of OBJTOHEX.COM.
+
    All these programs work by converting their arguments to a form
    suitable for zxcc, and then invoking zxcc.
 

--- a/zxcc.html
+++ b/zxcc.html
@@ -108,6 +108,7 @@ example, you would type <blockquote>zxc hello.c</blockquote> instead of
 <DT>zxas<DD>The equivalent of ZAS.COM.
 <DT>zxlink<DD>The equivalent of LINK.COM.
 <DT>zxlibr<DD>The equivalent of LIBR.COM.
+<DT>zxobjtohex<DD>The equivalent of OBJTOHEX.COM.
 </DL>
 
 <P>All these programs work by converting their arguments to a form suitable


### PR DESCRIPTION
I noticed that this tool was missing when I was experimenting with rebuilding `$EXEC.COM`.
Source code is based on the stripped down `zxas.c`.
To include it into the build system you should execute once:

```sh
./update-configure.sh
./configure
```

Then you can build it with:

```sh
make
```
